### PR TITLE
feat: add react configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,18 @@ npm install --save-dev @smooth-scrollbar-contrib/tsconfig
 
 ### Usage
 
-In `tsconfig.json`:
+#### 1. Use the base config:
 
 ```json
 {
   "extends": "@smooth-scrollbar-contrib/tsconfig",
+}
+```
+
+#### 2. Use for react projects
+
+```json
+{
+  "extends": "@smooth-scrollbar-contrib/tsconfig/tsconfig.react.json",
 }
 ```

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,8 @@
     "importHelpers": true,
     // force `import type` to be used instead of `import` when importing types
     "importsNotUsedAsValues": "error",
+    // ensure all files are modules
+    "isolatedModules": true,
     // use Node's module resolution algorithm, instead of the legacy TS one
     "moduleResolution": "node",
     // linter checks for common issues

--- a/tsconfig.react.json
+++ b/tsconfig.react.json
@@ -2,6 +2,7 @@
   // shared tsconfig for react projects
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
     // use the new jsx transform, see: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
     "jsx": "react-jsx",
     // enable `import react from 'react'

--- a/tsconfig.react.json
+++ b/tsconfig.react.json
@@ -1,0 +1,10 @@
+{
+  // shared tsconfig for react projects
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // use the new jsx transform, see: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
+    "jsx": "react-jsx",
+    // enable `import react from 'react'
+    "allowSyntheticDefaultImports": true,
+  }
+}


### PR DESCRIPTION
This PR added the shared tsconfig for react projects. Please notice that the following rules defined in `create-react-app` are removed:

| Rule | Reason |
|---|---|
| `"allowJs": true` | We should avoid using plain JS in our projects |
| `"noEmit": true` | This rule depends on the build tool. |
| `"resolveJsonModule": true` | We should enable this only when needed. |

I'm not sure if we should specify the `target` option. Most of our react packages would be transpiled in `es2016+`. 